### PR TITLE
adding LICENSE (BSD-3) and copyright statement

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2019, Hrafn Malmquist
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,10 @@ d.logout()
  
  ## TODO
  
+ ## LICENSE
+
+ Copyright (c) 2019, Hrafn Malmquist
+ All rights reserved.
+ 
+ This source code is licensed under the BSD-3-clause license found in the
+ LICENSE file in the root directory of this source tree.

--- a/dspace_rest_client.py
+++ b/dspace_rest_client.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2019, Hrafn Malmquist
+# All rights reserved.
+# 
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. 
+
 import datetime
 import json
 import logging

--- a/main.py
+++ b/main.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2019, Hrafn Malmquist
+# All rights reserved.
+# 
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from dspace_rest_client import DSpaceRestClient, Metadata, Collection
 import datetime
 


### PR DESCRIPTION
Here's the BSD-3 LICENSE file added to source root, and a short copyright statement with reference to the license added in each file header, and at the end of the README.md

(i've just applied this to master branch for now as I wasn't sure what 'global' branch represented, seems to be slightly updated?)